### PR TITLE
Fix project brief padding

### DIFF
--- a/src/doxygen-style.css
+++ b/src/doxygen-style.css
@@ -98,6 +98,10 @@ div.contents ul {
     padding: 0px 40px !important;
 }
 
+#projectbrief {
+    padding: 0px 40px !important;
+}
+
 #projectalign {
     padding: 0px !important;
 }


### PR DESCRIPTION
#### Before
![image](https://user-images.githubusercontent.com/1472411/118614213-18bde980-b7f2-11eb-80bb-e66f900e2fe9.png)

#### After
![image](https://user-images.githubusercontent.com/1472411/118614503-689cb080-b7f2-11eb-968a-4fdbaba12f93.png)

There was no padding for the project brief, added the padding to match the title.
